### PR TITLE
Switch to ruff for linting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'jogger'
-copyright = '2021, Alex Church'
+copyright = '2021, Alex Church'  # noqa: A001
 author = 'Alex Church'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'jogger'
-copyright = '2021, Alex Church'  # noqa: A001
+copyright = '2021, Alex Church'  # noqa: A001 (builtin shadowing)
 author = 'Alex Church'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/topics/builtins.rst
+++ b/docs/topics/builtins.rst
@@ -36,12 +36,12 @@ Performs a number of "linting" operations to flag potential errors and style gui
 
 It includes the following steps:
 
-1. Lint Python code using `flake8 <https://github.com/PyCQA/flake8>`_ and `isort <https://github.com/PyCQA/isort>`_. Both programs will obey their respective configuration files if they are located in standard locations, e.g. in a ``setup.cfg`` file. Specifically, the following commands are executed in the project root directory (determined as the directory containing ``jog.py``):
+1. Lint Python code using `ruff <https://docs.astral.sh/ruff/>`_ and `isort <https://github.com/PyCQA/isort>`_. Both programs will obey their respective configuration files if they are located in standard locations, e.g. in a ``setup.cfg`` file. Specifically, the following commands are executed in the project root directory (determined as the directory containing ``jog.py``):
 
-    * ``flake8 .``
+    * ``ruff check .``
     * ``isort --check-only --diff .``
 
-  This step can be skipped by default by using the ``python = false`` setting. It will also be skipped automatically if neither ``flake8`` or ``isort`` are installed.
+  This step can be skipped by default by using the ``python = false`` setting. It will also be skipped automatically if neither ``ruff`` or ``isort`` are installed.
 
 2. Run FABLE (Find All Bad Line Endings), a custom script to ensure all relevant project files use consistent line endings. By default, it:
 
@@ -51,17 +51,7 @@ It includes the following steps:
 
   This step can be skipped by default by using the ``fable = false`` setting.
 
-3. Check Python code for potential security issues using the static analysis tool `bandit <https://github.com/PyCQA/bandit>`_. Specifically, one of the following commands is executed in the project root directory (determined as the directory containing ``jog.py``):
-
-    * ``bandit . -r -q`` (default - use "quiet" mode, only generating output if an issue is found)
-    * ``bandit . -r`` (at verbosity level ``2``)
-    * ``bandit . -r -v`` (at verbosity level ``3`` - use "verbose" mode)
-
-  The program will obey a ``.bandit`` configuration file if found, but excludes can also be added via the task setting ``bandit_exclude``.
-
-  This step can be skipped by default by using the ``bandit = false`` setting. It will also be skipped automatically if ``bandit`` is not installed.
-
-4. Perform a "dry run" of Django's ``makemigrations`` management command, ensuring no migrations get missed.
+3. Perform a "dry run" of Django's ``makemigrations`` management command, ensuring no migrations get missed.
 
   This step can be skipped by default by using the ``migrations = false`` setting. It will also be skipped automatically if Django is not installed.
 
@@ -72,7 +62,6 @@ Arguments
 
 * ``-p``/``--python``: Only run the Python linting step.
 * ``-f``/``--fable``: Only run the FABLE step.
-* ``-b``/``--bandit``: Only run the ``bandit`` security scan step.
 * ``-m``/``--migrations``: Only run the migration check step.
 
 These arguments can be chained to specify any subset of these options, e.g.::
@@ -89,16 +78,12 @@ The following is an example config file section containing all available config 
     [jogger:lint]
     python = false      # exclude the Python linting step by default
     fable = false       # exclude the FABLE step by default
-    bandit = false      # exclude the bandit step by default
     migrations = false  # exclude the migration check step by default
 
     fable_good_endings = CRLF  # one of: LF, CR, CRLF (default: LF)
     fable_max_filesize = 5242880  # 5MB, in bytes (default: 1MB)
     fable_exclude =
         ./docs/_build
-
-    bandit_exclude =
-        tests
 
 
 ``TestTask``

--- a/jogger/tasks/base.py
+++ b/jogger/tasks/base.py
@@ -146,7 +146,7 @@ class BaseTask:
             if not self.using_system_err:
                 kwargs['stderr'] = self.kwargs['stderr']
         
-        return subprocess.run(cmd, shell=True, **kwargs)
+        return subprocess.run(cmd, shell=True, **kwargs)  # noqa: S602
     
     def execute(self):
         """
@@ -247,7 +247,7 @@ class Task(BaseTask):
                 tmpfile.write(default)
                 tmpfile.flush()
             
-            subprocess.run([editor, tmpfile.name])
+            subprocess.run([editor, tmpfile.name])  # noqa: S603
             
             tmpfile.seek(0)
             content = tmpfile.read().strip()

--- a/jogger/tasks/lint.py
+++ b/jogger/tasks/lint.py
@@ -6,25 +6,19 @@ from jogger.utils.files import walk
 from .base import Task, TaskError
 
 try:
-    import flake8  # noqa
-    HAS_FLAKE8 = True
+    import ruff  # noqa: F401
+    HAS_RUFF = True
 except ImportError:
-    HAS_FLAKE8 = False
+    HAS_RUFF = False
 
 try:
-    import isort  # noqa
+    import isort  # noqa: F401
     HAS_ISORT = True
 except ImportError:
     HAS_ISORT = False
 
 try:
-    import bandit  # noqa
-    HAS_BANDIT = True
-except ImportError:
-    HAS_BANDIT = False
-
-try:
-    from django.core.management import call_command  # noqa
+    from django.core.management import call_command  # noqa: F401
     HAS_DJANGO = True
 except ImportError:
     HAS_DJANGO = False
@@ -56,15 +50,14 @@ class LintTask(Task):
     
     help = (
         'Lint the project. Automatically detects, and uses if found, isort and '
-        'flake8 for linting Python code, and bandit for finding common security '
-        'issues in Python code. Also runs fable (Find All Bad Line Endings) and '
-        'performs a dry-run of makemigrations (if Django is detected).'
+        'ruff for linting and finding common security issues in Python code. '
+        'Also runs fable (Find All Bad Line Endings) and performs a dry-run of '
+        'makemigrations (if Django is detected).'
     )
     
     steps = [
         ('python', '-p', 'Perform linting of Python code.'),
         ('fable', '-f', 'Find all bad line endings.'),
-        ('bandit', '-b', 'Perform a Bandit security scan.'),
         ('migrations', '-m', 'Perform makemigrations dry-run.')
     ]
     
@@ -124,8 +117,8 @@ class LintTask(Task):
     
     def handle_python(self, explicit):
         
-        if explicit and not HAS_ISORT and not HAS_FLAKE8:
-            self.stderr.write('Cannot lint python: Neither isort nor flake8 are available.')
+        if explicit and not HAS_ISORT and not HAS_RUFF:
+            self.stderr.write('Cannot lint python: Neither isort nor ruff are available.')
             return
         
         if HAS_ISORT:
@@ -134,10 +127,10 @@ class LintTask(Task):
             self.outcomes['isort'] = result.returncode == 0
             self.stdout.write('')  # newline
         
-        if HAS_FLAKE8:
-            self.stdout.write('Running flake8...', style='label')
-            result = self.cli('flake8 .')
-            self.outcomes['flake8'] = result.returncode == 0
+        if HAS_RUFF:
+            self.stdout.write('Running ruff...', style='label')
+            result = self.cli('ruff check .')
+            self.outcomes['ruff'] = result.returncode == 0
             self.stdout.write('')  # newline
     
     def _get_fable_excludes(self):
@@ -196,38 +189,6 @@ class LintTask(Task):
             self.stdout.write(f'Skipped {skipped} large files')
         
         self.outcomes['fable'] = result
-        self.stdout.write('')  # newline
-    
-    def handle_bandit(self, explicit):
-        
-        if not HAS_BANDIT:
-            if explicit:
-                self.stderr.write('Cannot run bandit: Package is not available.')
-            
-            return
-        
-        self.stdout.write('Running bandit...', style='label')
-        
-        cmd = 'bandit . -r'
-        
-        # Set the command's verbosity based on the verbosity level of the task
-        verbosity = self.kwargs['verbosity']
-        if verbosity < 2:
-            cmd = f'{cmd} -q'  # run in "quiet" mode
-        elif verbosity > 2:
-            cmd = f'{cmd} -v'  # run in "verbose" mode
-        
-        # Add any configured excludes
-        try:
-            excludes = self.settings['bandit_exclude']
-        except KeyError:
-            pass
-        else:
-            excludes = ','.join(listify_multiline_string(excludes))
-            cmd = f'{cmd} -x {excludes}'
-        
-        result = self.cli(cmd)
-        self.outcomes['bandit'] = result.returncode == 0
         self.stdout.write('')  # newline
     
     def handle_migrations(self, explicit):

--- a/jogger/tasks/update.py
+++ b/jogger/tasks/update.py
@@ -13,7 +13,7 @@ class UpdateTask(Task):
         'collecting static files, and restarting the relevant services.'
     )
     
-    temp_requirements_dir = '/tmp'
+    temp_requirements_dir = '/tmp'  # noqa: S108
     default_branch_name = 'main'
     
     def add_arguments(self, parser):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,18 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 79
+extend-exclude = ["*/migrations/*"]
+
+[tool.ruff.lint]
+select = ["A", "DJ", "FLY", "E", "F", "S", "W", "C90"]
+ignore = ["W293", "A003"]
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 119
+max-doc-length = 119
+
+[tool.ruff.format]
+quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,19 @@ line-length = 79
 extend-exclude = ["*/migrations/*"]
 
 [tool.ruff.lint]
-select = ["A", "DJ", "FLY", "E", "F", "S", "W", "C90"]
-ignore = ["W293", "A003"]
+select = [
+    "A", # flake8-builtins
+    "C90", # McCabe complexity
+    "DJ", # flake8-django
+    "E", # pycodestyle errors
+    "F", # pyflakes
+    "FLY", # flynt (static-join-to-f-string)
+    "S", # flake8-bandit (security)
+    "W", # pycodestyle warnings
+]
+ignore = [
+    "W293" # blank line contains whitespace
+]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 119

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 build==0.3.1.post1
-flake8==3.9.0
 isort==5.8.0
+ruff==0.3.0
 sphinx==3.5.3
 sphinx-rtd-theme==0.5.2
 twine==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 build==0.3.1.post1
 isort==5.8.0
-ruff==0.3.0
+ruff==0.3.2
 sphinx==3.5.3
 sphinx-rtd-theme==0.5.2
 twine==3.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[flake8]
-exclude =
-    .git
-max-line-length = 119
-max-complexity = 10
-ignore =
-    # blank line contains whitespace
-    W293
-
 [isort]
 skip =
     .git
@@ -18,6 +9,7 @@ multi_line_output = 5
 fable_exclude =
     ./docs/_build
     ./dist
+    ./.ruff_cache/*
 
 [jogger:release]
 authoritative_version_path = ./jogger/__init__.py


### PR DESCRIPTION
- Replace flake8 and bandit with [ruff](https://docs.astral.sh/ruff/) python linter.
- Should be a lot faster when used in large Python repositories.